### PR TITLE
Adding logic to capture 'Default Backends' in K8s Ingress definitions

### DIFF
--- a/fern/definition/ingress.yml
+++ b/fern/definition/ingress.yml
@@ -1,29 +1,30 @@
 imports:
   common: ./common.yml
 types:
-  Rule:
+  RuleInfo:
     properties:
       path: string
       base: string
+      port: optional<string>
       serviceName: string
   Ingress:
     properties:
       name: string
       namespace: common.NamespaceInfo
-      rules: optional<list<Rule>>
+      rules: optional<list<RuleInfo>>
       annotations: optional<map<string, string>>
       labels: optional<map<string, string>>
   ServiceInfo:
     properties:
       name: string
       namespace: common.NamespaceInfo
-  Path:
+  PathInfo:
     properties:
       path: string
       base: string
       port: optional<string>
       service: ServiceInfo
-  Gateway:
+  GatewayInfo:
     properties:
       name: string
       namespace: common.NamespaceInfo
@@ -33,8 +34,8 @@ types:
       namespace: common.NamespaceInfo
       annotations: optional<map<string, string>>
       labels: optional<map<string, string>>
-      gateways: optional<list<Gateway>>
-      paths: optional<list<Path>>
+      gateways: optional<list<GatewayInfo>>
+      paths: optional<list<PathInfo>>
   IngressReport:
     properties:
       httpRoutes: optional<list<HttpRoute>>

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -121,7 +121,7 @@ func (p ProtocolTypes) Ptr() *ProtocolTypes {
 	return &p
 }
 
-type Gateway struct {
+type GatewayInfo struct {
 	Name      string         `json:"name" url:"name"`
 	Namespace *NamespaceInfo `json:"namespace,omitempty" url:"namespace,omitempty"`
 
@@ -129,17 +129,17 @@ type Gateway struct {
 	_rawJSON        json.RawMessage
 }
 
-func (g *Gateway) GetExtraProperties() map[string]interface{} {
+func (g *GatewayInfo) GetExtraProperties() map[string]interface{} {
 	return g.extraProperties
 }
 
-func (g *Gateway) UnmarshalJSON(data []byte) error {
-	type unmarshaler Gateway
+func (g *GatewayInfo) UnmarshalJSON(data []byte) error {
+	type unmarshaler GatewayInfo
 	var value unmarshaler
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
-	*g = Gateway(value)
+	*g = GatewayInfo(value)
 
 	extraProperties, err := core.ExtractExtraProperties(data, *g)
 	if err != nil {
@@ -151,7 +151,7 @@ func (g *Gateway) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (g *Gateway) String() string {
+func (g *GatewayInfo) String() string {
 	if len(g._rawJSON) > 0 {
 		if value, err := core.StringifyJSON(g._rawJSON); err == nil {
 			return value
@@ -168,8 +168,8 @@ type HttpRoute struct {
 	Namespace   *NamespaceInfo    `json:"namespace,omitempty" url:"namespace,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty" url:"annotations,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty" url:"labels,omitempty"`
-	Gateways    []*Gateway        `json:"gateways,omitempty" url:"gateways,omitempty"`
-	Paths       []*Path           `json:"paths,omitempty" url:"paths,omitempty"`
+	Gateways    []*GatewayInfo    `json:"gateways,omitempty" url:"gateways,omitempty"`
+	Paths       []*PathInfo       `json:"paths,omitempty" url:"paths,omitempty"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage
@@ -212,7 +212,7 @@ func (h *HttpRoute) String() string {
 type Ingress struct {
 	Name        string            `json:"name" url:"name"`
 	Namespace   *NamespaceInfo    `json:"namespace,omitempty" url:"namespace,omitempty"`
-	Rules       []*Rule           `json:"rules,omitempty" url:"rules,omitempty"`
+	Rules       []*RuleInfo       `json:"rules,omitempty" url:"rules,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty" url:"annotations,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty" url:"labels,omitempty"`
 
@@ -299,7 +299,7 @@ func (i *IngressReport) String() string {
 	return fmt.Sprintf("%#v", i)
 }
 
-type Path struct {
+type PathInfo struct {
 	Path    string       `json:"path" url:"path"`
 	Base    string       `json:"base" url:"base"`
 	Port    *string      `json:"port,omitempty" url:"port,omitempty"`
@@ -309,17 +309,17 @@ type Path struct {
 	_rawJSON        json.RawMessage
 }
 
-func (p *Path) GetExtraProperties() map[string]interface{} {
+func (p *PathInfo) GetExtraProperties() map[string]interface{} {
 	return p.extraProperties
 }
 
-func (p *Path) UnmarshalJSON(data []byte) error {
-	type unmarshaler Path
+func (p *PathInfo) UnmarshalJSON(data []byte) error {
+	type unmarshaler PathInfo
 	var value unmarshaler
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
-	*p = Path(value)
+	*p = PathInfo(value)
 
 	extraProperties, err := core.ExtractExtraProperties(data, *p)
 	if err != nil {
@@ -331,7 +331,7 @@ func (p *Path) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p *Path) String() string {
+func (p *PathInfo) String() string {
 	if len(p._rawJSON) > 0 {
 		if value, err := core.StringifyJSON(p._rawJSON); err == nil {
 			return value
@@ -343,26 +343,27 @@ func (p *Path) String() string {
 	return fmt.Sprintf("%#v", p)
 }
 
-type Rule struct {
-	Path        string `json:"path" url:"path"`
-	Base        string `json:"base" url:"base"`
-	ServiceName string `json:"serviceName" url:"serviceName"`
+type RuleInfo struct {
+	Path        string  `json:"path" url:"path"`
+	Base        string  `json:"base" url:"base"`
+	Port        *string `json:"port,omitempty" url:"port,omitempty"`
+	ServiceName string  `json:"serviceName" url:"serviceName"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage
 }
 
-func (r *Rule) GetExtraProperties() map[string]interface{} {
+func (r *RuleInfo) GetExtraProperties() map[string]interface{} {
 	return r.extraProperties
 }
 
-func (r *Rule) UnmarshalJSON(data []byte) error {
-	type unmarshaler Rule
+func (r *RuleInfo) UnmarshalJSON(data []byte) error {
+	type unmarshaler RuleInfo
 	var value unmarshaler
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
-	*r = Rule(value)
+	*r = RuleInfo(value)
 
 	extraProperties, err := core.ExtractExtraProperties(data, *r)
 	if err != nil {
@@ -374,7 +375,7 @@ func (r *Rule) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (r *Rule) String() string {
+func (r *RuleInfo) String() string {
 	if len(r._rawJSON) > 0 {
 		if value, err := core.StringifyJSON(r._rawJSON); err == nil {
 			return value

--- a/internal/ingress/ingress.go
+++ b/internal/ingress/ingress.go
@@ -16,7 +16,6 @@ import (
 )
 
 func init() {
-	// Register the Gateway API types with the scheme
 	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme.Scheme))
 }
 
@@ -26,7 +25,6 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 
 	config := k8sconfig
 
-	// Create a clientset for core resources (like namespaces)
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return &methodk8s.IngressReport{}, err
@@ -34,7 +32,6 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 
 	httpRoutes := []*methodk8s.HttpRoute{}
 	if contains(types, "gateway") || len(types) == 0 {
-		// Create a new Kubernetes client specific for gateways
 		k8sClient, err := client.New(config, client.Options{Scheme: scheme.Scheme})
 		if err != nil {
 			return &methodk8s.IngressReport{}, err
@@ -153,13 +150,43 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 
 				rules := []*methodk8s.Rule{}
 				for _, rule := range ingress.Spec.Rules {
+					baseHost := rule.Host
+					service, err := clientset.CoreV1().Services(ingress.GetNamespace()).Get(ctx, rule.HTTP.Paths[0].Backend.Service.Name, metav1.GetOptions{})
+					if err == nil && service.Spec.Ports != nil && len(service.Spec.Ports) > 0 {
+						port := fmt.Sprintf(":%d", service.Spec.Ports[0].Port)
+						baseHost += port
+					}
+
 					for _, path := range rule.HTTP.Paths {
 						ruleInfo := methodk8s.Rule{
 							Path:        path.Path,
-							Base:        rule.Host,
+							Base:        baseHost,
 							ServiceName: path.Backend.Service.Name,
 						}
 						rules = append(rules, &ruleInfo)
+					}
+				}
+
+				if ingress.Spec.DefaultBackend != nil {
+					service, err := clientset.CoreV1().Services(ingress.GetNamespace()).Get(ctx, ingress.Spec.DefaultBackend.Service.Name, metav1.GetOptions{})
+					if err != nil {
+						errors = append(errors, err.Error())
+					} else {
+						baseHost := ""
+						if len(ingress.Spec.TLS) > 0 && len(ingress.Spec.TLS[0].Hosts) > 0 {
+							baseHost = ingress.Spec.TLS[0].Hosts[0]
+						}
+						port := ""
+						if service.Spec.Ports != nil && len(service.Spec.Ports) > 0 {
+							port = fmt.Sprintf(":%d", service.Spec.Ports[0].Port)
+						}
+
+						defaultRule := &methodk8s.Rule{
+							Path:        "/",
+							Base:        baseHost + port,
+							ServiceName: service.Name,
+						}
+						rules = append(rules, defaultRule)
 					}
 				}
 

--- a/internal/ingress/ingress.go
+++ b/internal/ingress/ingress.go
@@ -47,6 +47,7 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 					errors = append(errors, err.Error())
 					continue
 				}
+				// Http Route Definition Namespace
 				namespaceInfo := methodk8s.NamespaceInfo{
 					Name: namespace.GetName(),
 					Uid:  string(namespace.GetUID()),
@@ -57,15 +58,16 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 					hostnames = append(hostnames, string(host))
 				}
 
-				gateways := []*methodk8s.Gateway{}
+				gateways := []*methodk8s.GatewayInfo{}
 				for _, gw := range route.Spec.ParentRefs {
+					// Gateway Namespace
 					gatewayNamespace, err := clientset.CoreV1().Namespaces().Get(ctx, string(*gw.Namespace), metav1.GetOptions{})
 					if err != nil {
 						errors = append(errors, err.Error())
 						continue
 					}
 
-					gatewayInfo := &methodk8s.Gateway{
+					gatewayInfo := &methodk8s.GatewayInfo{
 						Name: string(gw.Name),
 						Namespace: &methodk8s.NamespaceInfo{
 							Name: gatewayNamespace.GetName(),
@@ -75,7 +77,7 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 					gateways = append(gateways, gatewayInfo)
 				}
 
-				paths := []*methodk8s.Path{}
+				paths := []*methodk8s.PathInfo{}
 				for _, rule := range route.Spec.Rules {
 					for _, match := range rule.Matches {
 						if match.Path != nil && match.Path.Value != nil {
@@ -88,7 +90,7 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 									} else {
 										backendNamespace = route.GetNamespace()
 									}
-
+									// Service Namespace
 									backendNamespaceObj, err := clientset.CoreV1().Namespaces().Get(ctx, backendNamespace, metav1.GetOptions{})
 									if err != nil {
 										errors = append(errors, err.Error())
@@ -96,7 +98,7 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 									}
 									namespaceUID = string(backendNamespaceObj.GetUID())
 
-									pathInfo := &methodk8s.Path{
+									pathInfo := &methodk8s.PathInfo{
 										Path: *match.Path.Value,
 										Base: hostname,
 										Service: &methodk8s.ServiceInfo{
@@ -143,25 +145,25 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 					errors = append(errors, err.Error())
 					continue
 				}
+				//Ingress Namespace
 				namespaceInfo := methodk8s.NamespaceInfo{
 					Name: namespace.GetName(),
 					Uid:  string(namespace.GetUID()),
 				}
 
-				rules := []*methodk8s.Rule{}
+				rules := []*methodk8s.RuleInfo{}
 				for _, rule := range ingress.Spec.Rules {
-					baseHost := rule.Host
-					service, err := clientset.CoreV1().Services(ingress.GetNamespace()).Get(ctx, rule.HTTP.Paths[0].Backend.Service.Name, metav1.GetOptions{})
-					if err == nil && service.Spec.Ports != nil && len(service.Spec.Ports) > 0 {
-						port := fmt.Sprintf(":%d", service.Spec.Ports[0].Port)
-						baseHost += port
-					}
-
+					basePath := rule.Host
 					for _, path := range rule.HTTP.Paths {
-						ruleInfo := methodk8s.Rule{
+						ruleInfo := methodk8s.RuleInfo{
 							Path:        path.Path,
-							Base:        baseHost,
+							Base:        basePath,
 							ServiceName: path.Backend.Service.Name,
+						}
+						service, err := clientset.CoreV1().Services(ingress.GetNamespace()).Get(ctx, rule.HTTP.Paths[0].Backend.Service.Name, metav1.GetOptions{})
+						if err == nil && service.Spec.Ports != nil && len(service.Spec.Ports) > 0 {
+							port := fmt.Sprintf("%d", service.Spec.Ports[0].Port)
+							ruleInfo.Port = &port
 						}
 						rules = append(rules, &ruleInfo)
 					}
@@ -176,15 +178,15 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 						if len(ingress.Spec.TLS) > 0 && len(ingress.Spec.TLS[0].Hosts) > 0 {
 							baseHost = ingress.Spec.TLS[0].Hosts[0]
 						}
-						port := ""
-						if service.Spec.Ports != nil && len(service.Spec.Ports) > 0 {
-							port = fmt.Sprintf(":%d", service.Spec.Ports[0].Port)
-						}
 
-						defaultRule := &methodk8s.Rule{
+						defaultRule := &methodk8s.RuleInfo{
 							Path:        "/",
-							Base:        baseHost + port,
+							Base:        baseHost,
 							ServiceName: service.Name,
+						}
+						if service.Spec.Ports != nil && len(service.Spec.Ports) > 0 {
+							port := fmt.Sprintf("%d", service.Spec.Ports[0].Port)
+							defaultRule.Port = &port
 						}
 						rules = append(rules, defaultRule)
 					}
@@ -205,6 +207,7 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 	if len(httpRoutes) == 0 && len(ingresses) == 0 {
 		return &methodk8s.IngressReport{AuthType: authType, Errors: errors}, nil
 	}
+
 	resources = methodk8s.IngressReport{
 		HttpRoutes: httpRoutes,
 		Ingresses:  ingresses,
@@ -212,7 +215,6 @@ func EnumerateIngresses(ctx context.Context, k8sconfig *rest.Config, authType me
 		AuthType:   authType,
 		Errors:     errors,
 	}
-
 	return &resources, nil
 }
 


### PR DESCRIPTION
- A K8s Ingress definition can have a 'catch all' path that should be mapped as a Path.
- Logic was added to the Ingress Tool to capture this path