### PR TITLE
Adding 'Namespaces' to Service Account RBAC Policy

### DIFF
--- a/internal/serviceaccount/apply.go
+++ b/internal/serviceaccount/apply.go
@@ -82,7 +82,7 @@ func getClusterRole() *rbacv1.ClusterRole {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods", "services", "endpoints", "nodes"},
+				Resources: []string{"pods", "services", "endpoints", "nodes", "namespaces"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{


### PR DESCRIPTION
- Added 'namespaces' to the RBAC yaml binded to the 'method service account' when running `methodk8s serviceaccount config apply`