### PR TITLE
Remove signal output on serviceaccount configure commands

### DIFF
--- a/cmd/serviceaccount.go
+++ b/cmd/serviceaccount.go
@@ -1,20 +1,21 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/method-security/methodk8s/internal/serviceaccount"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/spf13/cobra"
 )
 
 func (a *MethodK8s) InitServiceAccountCommand() {
 	serviceAccountCmd := &cobra.Command{
-
 		Use:   "serviceaccount",
 		Short: "Configure, audit and command Service Accounts",
 		Long:  `Configure, audit and command Service Accounts`,
 	}
 
 	configureAccountCmd := &cobra.Command{
-
 		Use:   "configure",
 		Short: "Configure Service Account",
 		Long:  `Configure Service Account`,
@@ -26,28 +27,26 @@ func (a *MethodK8s) InitServiceAccountCommand() {
 		Long:  `Use this command to print the Service Account credentials`,
 		Run: func(cmd *cobra.Command, args []string) {
 			namespace, err := cmd.Flags().GetString("namespace")
+			log := svc1log.FromContext(cmd.Context())
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				log.Error(fmt.Sprintf("Failed to get namespace from command line arguments: %v", err))
 				return
 			}
 
 			secretname, err := cmd.Flags().GetString("secretname")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				log.Error(fmt.Sprintf("Failed to get secret name from command line arguments: %v", err))
 				return
 			}
 
 			err = serviceaccount.PrintCredentials(cmd.Context(), a.K8sConfig, namespace, secretname)
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				log.Error(fmt.Sprintf("Failed to gather credentials: %v", err))
+				return
 			}
-			a.OutputSignal.Content = nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			return nil
 		},
 	}
 	applyCmd := &cobra.Command{
@@ -55,29 +54,27 @@ func (a *MethodK8s) InitServiceAccountCommand() {
 		Short: "Create a service account in your k8s cluster",
 		Long:  `Create a service account in your k8s cluster`,
 		Run: func(cmd *cobra.Command, args []string) {
+			log := svc1log.FromContext(cmd.Context())
 			run, err := cmd.Flags().GetBool("run")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				log.Error(fmt.Sprintf("Failed to get run from command line arguments: %v", err))
 				return
 			}
 
 			namespace, err := cmd.Flags().GetString("namespace")
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				log.Error(fmt.Sprintf("Failed to get namespace from command line arguments: %v", err))
 				return
 			}
 
 			err = serviceaccount.Config(cmd.Context(), a.K8sConfig, run, namespace)
 			if err != nil {
-				errorMessage := err.Error()
-				a.OutputSignal.ErrorMessage = &errorMessage
-				a.OutputSignal.Status = 1
+				log.Error(fmt.Sprintf("Failed to create service account yaml: %v", err))
+				return
 			}
-			a.OutputSignal.Content = nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			return nil
 		},
 	}
 


### PR DESCRIPTION
Removes the persistent post run function from the service account apply and configure commands. This ensures we don't print an empty signal JSON after running these commands that are intended to be utilities run by a user.